### PR TITLE
Include *.sql in MANIFEST.in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ That is, given a version number `MAJOR.MINOR.PATCH`, increment the:
 - **MINOR** version when you add functionality in a backwards compatible manner
 - **PATCH** version when you make backwards compatible bug fixes
 
+## [0.4.1] - 2023-10-10
+### Fixed
+- Manifest includes `.sql` files now; as was excluding the CREATE TABLE SQL query before, causing errors.
+
 ## [0.4.1] - 2023-10-09
 ### Fixed
 - Issue with unpacking in typing hint (in Python version `3.10` and less); removed.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 global-include *.py
+global-include *.sql

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = simpleboto
 url = https://github.com/ccollier97/simpleboto/
-version = 0.4.1
+version = 0.4.2
 
 author = Charlie Collier
 


### PR DESCRIPTION
Was excluding the .sql create table SQL file, which is needed for CREATE TABLE functionality in AthenaClient.